### PR TITLE
chore: Update PaymentStatus enum values

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -241,10 +241,14 @@ model payment {
 }
 
 enum RegistrationOrderStatus {
+  OPEN
+  CANCELED
+  PENDING
+  AUTHORIZED
+  EXPIRED
+  FAILED
   PAID
   REFUNDED
-  PENDING
-  FAILED
 }
 
 model registrationOrder {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,10 +210,14 @@ enum PaymentProduct {
 }
 
 enum PaymentStatus {
+  OPEN
+  CANCELED
+  PENDING
+  AUTHORIZED
+  EXPIRED
+  FAILED
   PAID
   REFUNDED
-  PENDING
-  FAILED
 }
 
 model payment {
@@ -366,10 +370,10 @@ model userTokens {
 }
 
 model TeslaToken {
-  id                Int      @id @default(autoincrement())
-  token             String
-  refreshToken      String
-  createdAt         DateTime @default(now())
+  id           Int      @id @default(autoincrement())
+  token        String
+  refreshToken String
+  createdAt    DateTime @default(now())
 }
 
 model Refunds {

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -114,7 +114,6 @@ export default class PaymentService {
   public async updateOrderPaymentStatus(paymentId: string) {
     try {
       const payment = await this.mollie.payments.get(paymentId);
-      console.log({ payment });
 
       const updatedPayment = await prisma.payment.update({
         where: { orderId: payment.metadata.orderId },


### PR DESCRIPTION
The PaymentStatus enum in the schema.prisma file has been updated to include new values: OPEN, CANCELED, AUTHORIZED, and EXPIRED. This change reflects the expanded range of payment status options in the system.

The purpose of this PR is to solve this issue:

```
PrismaClientValidationError

Invalid `prisma.payment.update()` invocation:

{
  where: {
    registrationOrderId: "7d785822-97ec-42a6-897b-2549f3ff5d8b"
  },
  data: {
    status: "EXPIRED"
            ~~~~~~~~~
  }
}

Invalid value for argument `status`. Expected PaymentStatus...
```